### PR TITLE
Release 3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+### 3.1.3
+
+- fix: `RdSlider` can now display values when used with `RdControl`
+- fix: `RdSlider` vertical slider values were offset
+- fix: `RdRadioGroup` radio group selection when set with control group
+- fix: `RdDropdown` select menu should display default as first option
+- fix: `RdDropdown` select menu should not display empty last option
+
 ### 3.1.2
 
 - fix: `RdSlider` should initialize with the correct position when using a control

--- a/src/client/app/view/lib/lib.ts
+++ b/src/client/app/view/lib/lib.ts
@@ -272,15 +272,16 @@ class LibraryComponent extends CustomElement {
           selector: 'rd-slider',
           channel: this.channelName,
           control: {
-            type: 'vert',
+            type: 'hor',
             name: 'slider',
             currentValue: 100,
             attributes: {
-              orient: 'is--vert',
+              orient: 'is--hor',
               min: 0,
               max: 200,
             },
           },
+          displayValue: true,
           hint: {
             template: documentation.slider,
           },
@@ -301,6 +302,7 @@ class LibraryComponent extends CustomElement {
               numberType: 'int',
             },
           },
+          displayValue: true,
           hint: {
             template: documentation.slider,
           },
@@ -337,7 +339,7 @@ class LibraryComponent extends CustomElement {
                   {
                     selector: '[key="Enter"]',
                     styles: {
-                      width: '100%',
+                      width: 'calc(100% - 8px)',
                       gridColumn: 'span 2',
                     },
                   },

--- a/src/modules/core/package.json
+++ b/src/modules/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readymade/core",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "JavaScript microlibrary for developing Web Components with TypeScript and Decorators",
   "type": "module",
   "module": "./fesm2022/index.js",

--- a/src/modules/dom/package.json
+++ b/src/modules/dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readymade/dom",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "JavaScript microlibrary for developing Web Components with TypeScript and Decorators",
   "type": "module",
   "module": "./fesm2022/index.js",

--- a/src/modules/router/package.json
+++ b/src/modules/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readymade/router",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "JavaScript microlibrary for developing Web Components with TypeScript and Decorators",
   "type": "module",
   "module": "./fesm2022/index.js",

--- a/src/modules/transmit/package.json
+++ b/src/modules/transmit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readymade/transmit",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Swiss-army knife for communicating over WebRTC DataChannel, WebSocket or Touch OSC",
   "type": "module",
   "module": "./fesm2022/index.js",

--- a/src/modules/ui/component/control.ts
+++ b/src/modules/ui/component/control.ts
@@ -47,6 +47,7 @@ export interface RdControlSurfaceElement<C> {
   hint?: {
     template: string;
   };
+  displayValue?: boolean;
 }
 
 export interface RdControlSurface {

--- a/src/modules/ui/component/index.ts
+++ b/src/modules/ui/component/index.ts
@@ -15,4 +15,4 @@ export { RdTextArea } from './input/textarea';
 export { RdDropdown } from './input/select';
 export { RdSlider } from './input/slider';
 export { RdDial } from './input/dial';
-export { RdSurface, RdSurfaceElement } from './surface';
+export { RdSurface, RdSurfaceElement, RdDisplayInput } from './surface';

--- a/src/modules/ui/component/input/radio.ts
+++ b/src/modules/ui/component/input/radio.ts
@@ -262,7 +262,8 @@ class RdRadioGroup extends FormElement {
         elem.onblur = () => {
           this.onValidate();
         };
-        elem.onclick = (ev: MouseEvent) => {
+        elem.onchange = (ev: MouseEvent) => {
+          this.value = (ev.target as HTMLInputElement).value;
           if (this.channel) {
             this.control.currentValue = (ev.target as HTMLInputElement).value;
             this.channel.postMessage(this.control);

--- a/src/modules/ui/component/input/select.ts
+++ b/src/modules/ui/component/input/select.ts
@@ -206,7 +206,13 @@ class RdDropdown extends FormElement {
     if (control.attributes.options) {
       this.innerHTML = '';
       const select = document.createElement('select');
-      for (let i = 0; i <= control.attributes.options.length; i++) {
+
+      const defaultOption = document.createElement('option');
+      defaultOption.value = '';
+      defaultOption.text = 'Select an option';
+      select.appendChild(defaultOption);
+
+      for (let i = 0; i < control.attributes.options.length; i++) {
         const option = document.createElement('option');
         option.textContent = control.attributes.options[i];
         select.appendChild(option);

--- a/src/modules/ui/component/input/slider.ts
+++ b/src/modules/ui/component/input/slider.ts
@@ -736,7 +736,7 @@ class RdSlider extends FormElement {
         this.scale(
           this.control.attributes.x as number,
           0,
-          this.control.attributes.width - this.$handle.offsetWidth,
+          168,
           <number>this.control.attributes.min,
           <number>this.control.attributes.max,
         ),
@@ -747,7 +747,7 @@ class RdSlider extends FormElement {
         this.scale(
           this.control.attributes.y as number,
           0,
-          this.control.attributes.height - this.$handle.offsetHeight,
+          168,
           <number>this.control.attributes.min,
           <number>this.control.attributes.max,
         ),

--- a/src/modules/ui/component/surface/display-input.ts
+++ b/src/modules/ui/component/surface/display-input.ts
@@ -1,0 +1,63 @@
+import { Component, html, css } from '@readymade/core';
+import { RdControl } from '../control';
+import { RdInput, RdInputAttributes } from '../input/input';
+
+@Component({
+  selector: 'rd-displayinput',
+  delegatesFocus: true,
+  style: css`
+    :host {
+      display: inline-block;
+      outline: none;
+      padding: 0;
+    }
+    :host input {
+      height: 16px;
+      width: 36px;
+      background-color: var(--ready-color-bg);
+      border: var(--ready-border-width) solid var(--ready-color-border);
+      border-radius: var(--ready-border-radius);
+      color: var(--ready-color-default);
+      font: var(--font-family);
+      min-height: 2em;
+      padding: 0em 1em;
+    }
+    :host input:hover,
+    :host input:focus,
+    :host input:active {
+      border: var(--ready-border-width) solid var(--ready-color-highlight);
+      outline: none;
+      box-shadow: none;
+    }
+    :host input[disabled] {
+      opacity: var(--ready-opacity-disabled);
+      background: var(--ready-color-disabled);
+      cursor: not-allowed;
+    }
+    :host input[disabled]:hover,
+    :host input[disabled]:focus,
+    :host input[disabled]:active {
+      border: var(--ready-border-width) solid var(--ready-color-border);
+      outline: none;
+      box-shadow: none;
+    }
+    :host input.required,
+    :host input.required:hover,
+    :host input.required:focus,
+    :host input.required:active {
+      border: var(--ready-border-width) solid var(--ready-color-error);
+      outline: none;
+      box-shadow: none;
+    }
+  `,
+  template: html` <input type="text" /> `,
+})
+class RdDisplayInput extends RdInput {
+  channel: BroadcastChannel;
+  control: RdControl<RdInputAttributes>;
+  constructor() {
+    super();
+  }
+}
+
+export { RdDisplayInput };

--- a/src/modules/ui/component/surface/element.ts
+++ b/src/modules/ui/component/surface/element.ts
@@ -1,6 +1,6 @@
 import { Component, css } from '@readymade/core';
-import { RdControlSurfaceElement } from '../control';
 import { BlockComponent } from '@readymade/dom';
+import { RdControlSurfaceElement } from '../control';
 
 @Component({
   selector: 'rd-element',
@@ -10,7 +10,10 @@ import { BlockComponent } from '@readymade/dom';
       flex-direction: column;
     }
     .surface-label {
-      margin-bottom: 1em;
+      display: flex;
+      align-items: center;
+      margin-bottom: 0.75em;
+      height: 36px;
     }
     .surface-label .hint {
       display: inline-block;
@@ -40,6 +43,16 @@ import { BlockComponent } from '@readymade/dom';
       inset: auto;
       overflow: scroll;
     }
+    .rd-display-value {
+      height: 36px;
+      &.hidden {
+        display: none;
+      }
+    }
+    rd-displayinput {
+      display: inline-block;
+      margin-left: 10px;
+    }
     ::backdrop {
       background: var(--ready-popover-bg);
     }
@@ -47,6 +60,7 @@ import { BlockComponent } from '@readymade/dom';
   custom: { extends: 'div' },
 })
 class RdSurfaceElement extends BlockComponent {
+  timeout$: any;
   constructor() {
     super();
   }
@@ -91,6 +105,12 @@ class RdSurfaceElement extends BlockComponent {
       this.appendChild(dialog);
     }
 
+    if (surface.displayValue === true) {
+      const displayValue = document.createElement('span');
+      displayValue.classList.add('rd-display-value');
+      label.appendChild(displayValue);
+    }
+
     this.appendChild(label);
     this.appendChild(element);
 
@@ -98,6 +118,64 @@ class RdSurfaceElement extends BlockComponent {
 
     if (surface.channel) {
       (element as any).setChannel(surface.channel);
+    }
+
+    if (surface.displayValue === true) {
+      (element as any).onchange = () => {
+        const displayValue = this.querySelector('.rd-display-value');
+        displayValue.classList.remove('hidden');
+        window.clearTimeout(this.timeout$);
+        if (displayValue) {
+          let inputDebounce: any;
+          displayValue.innerHTML = '';
+          if (Array.isArray((element as any).value)) {
+            (element as any).value.forEach((value, index) => {
+              const input = document.createElement(
+                'rd-displayinput',
+              ) as HTMLInputElement;
+              input.classList.add('rd-display-input');
+              input.value = value;
+              displayValue.appendChild(input);
+              input.oninput = () => {
+                window.clearTimeout(this.timeout$);
+                inputDebounce = setTimeout(() => {
+                  const inputValues = (element as any).value;
+                  if (
+                    surface.control.currentValue.some(
+                      (val) => typeof val === 'number',
+                    )
+                  ) {
+                    inputValues[index] = parseFloat(input.value);
+                  } else {
+                    inputValues[index] = input.value;
+                  }
+                  (element as any).value = inputValues;
+                }, 400);
+              };
+            });
+          } else {
+            const input = document.createElement(
+              'rd-displayinput',
+            ) as HTMLInputElement;
+            input.classList.add('rd-display-input');
+            input.value = (element as any).value;
+            displayValue.appendChild(input);
+            input.oninput = () => {
+              window.clearTimeout(inputDebounce);
+              inputDebounce = setTimeout(() => {
+                if (typeof surface.control.currentValue === 'number') {
+                  (element as any).value = parseFloat(input.value);
+                } else {
+                  (element as any).value = input.value;
+                }
+              }, 400);
+            };
+          }
+        }
+        this.timeout$ = setTimeout(() => {
+          displayValue.classList.add('hidden');
+        }, 4000);
+      };
     }
   }
 }

--- a/src/modules/ui/component/surface/index.ts
+++ b/src/modules/ui/component/surface/index.ts
@@ -1,2 +1,3 @@
 export { RdSurface } from './surface';
 export { RdSurfaceElement } from './element';
+export { RdDisplayInput } from './display-input';

--- a/src/modules/ui/index.ts
+++ b/src/modules/ui/index.ts
@@ -15,6 +15,7 @@ export {
   RdDial,
   RdSurface,
   RdSurfaceElement,
+  RdDisplayInput,
 } from './component';
 export type {
   RdLegacyControl,

--- a/src/modules/ui/package.json
+++ b/src/modules/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readymade/ui",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "UI library of standard elements built with Readymade",
   "type": "module",
   "module": "./fesm2022/index.js",


### PR DESCRIPTION
- fix: `RdSlider` can now display values when used with `RdControl`
- fix: `RdSlider` vertical slider values were offset
- fix: `RdRadioGroup` radio group selection when set with control group
- fix: `RdDropdown` select menu should display default as first option
- fix: `RdDropdown` select menu should not display empty last option